### PR TITLE
Adding PowerShell Module Indented.Net.Dns

### DIFF
--- a/Kubernetes/Continuous Integration/Dockerfile
+++ b/Kubernetes/Continuous Integration/Dockerfile
@@ -131,7 +131,7 @@ RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
   && rm -rf /etc/apt/sources.list.d/*
 
 # Install Powershell Modules
-RUN pwsh -NonInteractive -Command '$null = Install-Module PSScriptAnalyzer, Pester, Az, AWSPowerShell.NetCore -Scope AllUsers -Force'
+RUN pwsh -NonInteractive -Command '$null = Install-Module PSScriptAnalyzer, Pester, Az, AWSPowerShell.NetCore, Indented.Net.Dns -Scope AllUsers -Force'
 
 # # Install Gitversion
 # RUN apt-get update \


### PR DESCRIPTION
- Adding the PowerShell module `Indented.Net.Dns`. This is a module that allows DNS resolution on both Windows and Linux using the cmdlet `Get-Dns`.
https://www.powershellgallery.com/packages/Indented.Net.Dns/6.1.1
https://github.com/indented-automation/Indented.Net.Dns
- The built-in cmdlet `Resolve-DnsName` does not work on Linux and therefore I needed a cmdlet that was compatible on both Windows and Linux. 
- This is in preparation for my `das-dns-automation-cleanup` solution that uses it to test whether a DNS record we've marked as `inactive` still resolves or not. 
- It needs to be available on the build agents so that when the Pester tests run it's available to mock. The script that will run at release will install if required.