### PR TITLE
Increase vmSize for Linux pool

### DIFF
--- a/cluster.template.json
+++ b/cluster.template.json
@@ -74,7 +74,7 @@
         "name": "[parameters('linuxPoolName')]",
         "os": "Linux",
         "nodeCount": "[parameters('linuxNodeCount')]",
-        "vmSize": "Standard_DS2_v2",
+        "vmSize": "Standard_DS3_v2",
         "nodeTaints": [
           "agent-os=linux:NoSchedule"
         ]

--- a/cluster.template.json
+++ b/cluster.template.json
@@ -74,7 +74,7 @@
         "name": "[parameters('linuxPoolName')]",
         "os": "Linux",
         "nodeCount": "[parameters('linuxNodeCount')]",
-        "vmSize": "Standard_DS3_v2",
+        "vmSize": "Standard_D4ds_v4",
         "nodeTaints": [
           "agent-os=linux:NoSchedule"
         ]


### PR DESCRIPTION
The current VM Size has 7GB memory.
The kubelet daemon reserves 750MB,
Then the following is kube-reserved.
25% of the first 4 GB of memory
20% of the next 4 GB of memory (up to 8 GB)
10% of the next 8 GB of memory (up to 16 GB)
6% of the next 112 GB of memory (up to 128 GB)
2% of any memory above 128 GB

For the 7GB VM size, 2.35GB is reserved from above. 
Then 15 pods are setup ready for jobs. These idle at around 100MB each.

So of the 7GB you're left with roughly 3.15GB.
One das-admin-service build running sonarscan takes up 1GB of this. 

The thought is to increase this to a vm size with 14GB. So that including the 15 pods 4.65GB is reserved leaving 9.35GB spare. A significant increase for one tier bump.