### PR TITLE
Add limits to Linux build agents

### DIFF
--- a/Linux/Build/manifest.yml
+++ b/Linux/Build/manifest.yml
@@ -41,6 +41,9 @@ spec:
       containers:
         - name: azure-pipelines-build-agent
           image: apprenticeshipsdevops/azure-pipelines-build-agent:__ImageVersion__
+          resources:
+            limits:
+              memory: 1Gi
           env:
             - name: AZP_URL
               valueFrom:

--- a/Linux/Build/manifest.yml
+++ b/Linux/Build/manifest.yml
@@ -42,8 +42,8 @@ spec:
         - name: azure-pipelines-build-agent
           image: apprenticeshipsdevops/azure-pipelines-build-agent:__ImageVersion__
           resources:
-            limits:
-              memory: 1Gi
+            requests:
+              memory: 512Mi
           env:
             - name: AZP_URL
               valueFrom:


### PR DESCRIPTION
Setting a limit of 1gb will balance the 15 pods across the 2 nodes.