### PR TITLE
DASD-8806 Cache tasks

### DIFF
--- a/Windows/Deploy-Base/Start.ps1
+++ b/Windows/Deploy-Base/Start.ps1
@@ -54,8 +54,8 @@ try {
 		--replace
 
 	Write-Host "4. Running Azure Pipelines agent..." -ForegroundColor Cyan
-	
-	.\run.cmd
+
+	.\run.cmd --once
 }
 finally {
 	Write-Host "Cleanup. Removing Azure Pipelines agent..." -ForegroundColor Cyan

--- a/Windows/Deploy-Base/Start.ps1
+++ b/Windows/Deploy-Base/Start.ps1
@@ -55,6 +55,7 @@ try {
 
 	Write-Host "4. Running Azure Pipelines agent..." -ForegroundColor Cyan
 	
+	.\run.cmd
 }
 finally {
 	Write-Host "Cleanup. Removing Azure Pipelines agent..." -ForegroundColor Cyan

--- a/Windows/Deploy-Base/Start.ps1
+++ b/Windows/Deploy-Base/Start.ps1
@@ -19,7 +19,7 @@ if ($Env:AZP_WORK -and -not (Test-Path Env:AZP_WORK)) {
 	New-Item $Env:AZP_WORK -ItemType directory | Out-Null
 }
 
-New-Item "\azp\agent" -ItemType directory | Out-Null
+New-Item "\azp\agent" -ItemType directory -ErrorAction SilentlyContinue | Out-Null
 
 # Let the agent ignore the token env variables
 $Env:VSO_AGENT_IGNORE = "AZP_TOKEN,AZP_TOKEN_FILE"

--- a/Windows/Deploy-Base/Start.ps1
+++ b/Windows/Deploy-Base/Start.ps1
@@ -19,7 +19,8 @@ if ($Env:AZP_WORK -and -not (Test-Path Env:AZP_WORK)) {
 	New-Item $Env:AZP_WORK -ItemType directory | Out-Null
 }
 
-New-Item "\azp\agent" -ItemType directory -ErrorAction SilentlyContinue | Out-Null
+# This will error due to directory already existing because of the volume mount. Script still continues and successfully starts up the agent.
+New-Item "\azp\agent" -ItemType directory | Out-Null
 
 # Let the agent ignore the token env variables
 $Env:VSO_AGENT_IGNORE = "AZP_TOKEN,AZP_TOKEN_FILE"

--- a/Windows/Deploy-Base/Start.ps1
+++ b/Windows/Deploy-Base/Start.ps1
@@ -54,8 +54,7 @@ try {
 		--replace
 
 	Write-Host "4. Running Azure Pipelines agent..." -ForegroundColor Cyan
-
-	.\run.cmd --once
+	
 }
 finally {
 	Write-Host "Cleanup. Removing Azure Pipelines agent..." -ForegroundColor Cyan

--- a/Windows/Deploy/Dockerfile
+++ b/Windows/Deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM apprenticeshipsdevops/azure-pipelines-base-deploy-agent-win:20210526.1
+FROM apprenticeshipsdevops/azure-pipelines-base-deploy-agent-win:20210527.1
 
 ENV chocolateyUseWindowsCompression=false
 RUN @powershell -NoProfile -ExecutionPolicy Bypass -Command "iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))" && SET "PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin"

--- a/Windows/Deploy/Dockerfile
+++ b/Windows/Deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM apprenticeshipsdevops/azure-pipelines-base-deploy-agent-win:20210527.1
+FROM apprenticeshipsdevops/azure-pipelines-base-deploy-agent-win:latest
 
 ENV chocolateyUseWindowsCompression=false
 RUN @powershell -NoProfile -ExecutionPolicy Bypass -Command "iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))" && SET "PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin"

--- a/Windows/Deploy/Dockerfile
+++ b/Windows/Deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM apprenticeshipsdevops/azure-pipelines-base-deploy-agent-win:latest
+FROM apprenticeshipsdevops/azure-pipelines-base-deploy-agent-win:20210526.1
 
 ENV chocolateyUseWindowsCompression=false
 RUN @powershell -NoProfile -ExecutionPolicy Bypass -Command "iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))" && SET "PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin"

--- a/Windows/Deploy/manifest.yml
+++ b/Windows/Deploy/manifest.yml
@@ -1,9 +1,10 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: azure-pipelines-deploy-agent-win
   namespace: __agentNameSpace__
 spec:
+  serviceName: __agentServiceName
   replicas: __agentCount__
   revisionHistoryLimit: 2
   selector:
@@ -36,32 +37,44 @@ spec:
                         - azure-pipelines-deploy-agent-win
                 topologyKey: failure-domain.beta.kubernetes.io/zone
       containers:
-        - name: azure-pipelines-deploy-agent-win
-          image: apprenticeshipsdevops/azure-pipelines-deploy-agent-win:__ImageVersion__
-          resources:
-            requests:
-              memory: 256Mi
-          env:
-            - name: AZP_URL
-              valueFrom:
-                secretKeyRef:
-                  name: azp
-                  key: AZP_URL
-            - name: AZP_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: azp
-                  key: AZP_TOKEN
-            - name: AZP_POOL
-              value: DAS - Continuous Deployment Agents
-            - name: NUGET_PACKAGES
-              value: "D:\\nugetcache\\packages"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
+      - name: azure-pipelines-deploy-agent-win
+        image: apprenticeshipsdevops/azure-pipelines-deploy-agent-win:__ImageVersion__
+        resources:
+          requests:
+            memory: 256Mi
+        env:
+          - name: AZP_URL
+            valueFrom:
+              secretKeyRef:
+                name: azp
+                key: AZP_URL
+          - name: AZP_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: azp
+                key: AZP_TOKEN
+          - name: AZP_POOL
+            value: DAS - Continuous Deployment Agents
+          - name: NUGET_PACKAGES
+            value: "D:\\nugetcache\\packages"
+          - name: POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+        volumeMounts:
+          - name: dynamic
+            mountPath: /azp/agent/_work/_tasks
       tolerations:
         - key: agent-os
           operator: Equal
           value: windows
           effect: NoSchedule
+  volumeClaimTemplates:
+  - metadata:
+      name: dynamic
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      storageClassName: default
+      resources:
+        requests:
+          storage: 4Gi

--- a/Windows/Deploy/manifest.yml
+++ b/Windows/Deploy/manifest.yml
@@ -4,7 +4,7 @@ metadata:
   name: azure-pipelines-deploy-agent-win
   namespace: __agentNameSpace__
 spec:
-  serviceName: __agentServiceName
+  serviceName: __agentServiceName__
   replicas: __agentCount__
   revisionHistoryLimit: 2
   selector:


### PR DESCRIPTION
- Number of pods will need to reduce to 12 from 15 due to persistent volume, node count/VM size restraints
- When deleting a Statefulset, the persistent volume claims do not auto delete themselves and thus the persistent volumes also do not auto delete. This is also the case when number of replicas are decreased eg: 12 agents down to 10. Two persistent volumes will not be deleted. https://github.com/kubernetes/kubernetes/issues/55045
- disks are using default StorageClassName using Standard SSD's
- disks are sized 4Gi the lowest tier available. Anything set under 4Gi will not have any cost saving effect - https://azure.microsoft.com/en-gb/pricing/details/managed-disks/