### PR TITLE
Dasd 9079 Windows/Deploy/Dockerfile: Added choco install of mongodb cli

### DIFF
--- a/Windows/Deploy/Dockerfile
+++ b/Windows/Deploy/Dockerfile
@@ -9,7 +9,6 @@ RUN choco config set cachelocation C:\chococache \
 RUN choco install \
   git  \
   powershell-core \
-  az.powershell /core /desktop \
   mongodb-cli \
   dacfx-18 \
   --confirm \
@@ -19,6 +18,10 @@ RUN choco install \
 
 RUN  @powershell -NoProfile -Command "Install-PackageProvider -Name NuGet -Force"
 
+RUN  @powershell -NoProfile -Command "Install-Module Az -Force"
+
 RUN  @pwsh -NoProfile -Command "Invoke-WebRequest -Uri https://aka.ms/installazurecliwindows -OutFile .\AzureCLI.msi; Start-Process msiexec.exe -Wait -ArgumentList '/I AzureCLI.msi /quiet'; rm .\AzureCLI.msi"
+
+RUN  @pwsh -NoProfile -Command "Install-Module Az -Force"
 
 RUN  @pwsh -NoProfile -Command "Install-Module SqlServer, AzTable -Force"


### PR DESCRIPTION
mongodb-cli is needed for das-recruit release's `Run Mongo API Script` task https://github.com/SkillsFundingAgency/das-recruit/blob/5a6aea93ae7583135a7510267af4d9d0c5145826/pipeline-templates/job/deploy.yml#L44-L49