### PR TITLE
DASD-9313 - Move Azure and AWS Pwsh Modules to Win deploy agents

### DIFF
--- a/Linux/Build/Dockerfile
+++ b/Linux/Build/Dockerfile
@@ -118,7 +118,7 @@ RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
   && rm -rf /etc/apt/sources.list.d/*
 
 # Install Powershell Modules
-RUN pwsh -NonInteractive -Command '$null = Install-Module PSScriptAnalyzer, Az, Az.CosmosDb, AWSPowerShell.NetCore -Scope AllUsers -Force'
+RUN pwsh -NonInteractive -Command '$null = Install-Module PSScriptAnalyzer -Scope AllUsers -Force'
 RUN pwsh -NonInteractive -Command '$null = Install-Module Pester -RequiredVersion 4.10.1 -Scope AllUsers -Force'
 
 # Install az cli

--- a/Windows/Deploy/Dockerfile
+++ b/Windows/Deploy/Dockerfile
@@ -33,4 +33,4 @@ SHELL ["pwsh", "-NoProfile", "-Command"]
 RUN Invoke-WebRequest -Uri https://aka.ms/installazurecliwindows -OutFile .\AzureCLI.msi; Start-Process msiexec.exe -Wait -ArgumentList '/I AzureCLI.msi /quiet'; rm .\AzureCLI.msi
 RUN Invoke-WebRequest -Uri https://aka.ms/dacfx-msi -OutFile .\dacfx.msi; Start-Process msiexec.exe -Wait -ArgumentList '/I dacfx.msi /quiet'; rm .\dacfx.msi
 RUN Install-Module Az -Force
-RUN Install-Module SqlServer, AzTable -Force
+RUN Install-Module SqlServer, Az, AzTable, AWSPowerShell.NetCore -Force


### PR DESCRIPTION
Removed AZ and AWS Modules from linux build agents and moved them to windows deploy agents