### PR TITLE
Restore AWSPowerShell.NetCore to Linux Build

### DIFF
--- a/Linux/Build/Dockerfile
+++ b/Linux/Build/Dockerfile
@@ -118,7 +118,7 @@ RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
   && rm -rf /etc/apt/sources.list.d/*
 
 # Install Powershell Modules
-RUN pwsh -NonInteractive -Command '$null = Install-Module PSScriptAnalyzer, powershell-yaml -Scope AllUsers -Force'
+RUN pwsh -NonInteractive -Command '$null = Install-Module PSScriptAnalyzer, powershell-yaml, AWSPowerShell.NetCore -Scope AllUsers -Force'
 RUN pwsh -NonInteractive -Command '$null = Install-Module Pester -RequiredVersion 4.10.1 -Scope AllUsers -Force'
 
 # Install az cli


### PR DESCRIPTION
The unit tests for DNS config require this module.