### PR TITLE
Agents images schedule change

### DIFF
--- a/Linux/Build/Image/azure-pipelines.yml
+++ b/Linux/Build/Image/azure-pipelines.yml
@@ -23,8 +23,8 @@ resources:
     endpoint: SFA
 
 schedules:
-- cron: "0 0 * * Wed"
-  displayName: Weekly Wednesday midnight run
+- cron: "0 6 * * Wed"
+  displayName: Weekly Wednesday morning run
   branches:
     include:
     - master

--- a/Linux/Build/Image/azure-pipelines.yml
+++ b/Linux/Build/Image/azure-pipelines.yml
@@ -23,8 +23,8 @@ resources:
     endpoint: SFA
 
 schedules:
-- cron: "0 6 * * Tue"
-  displayName: Weekly Tuesday morning build
+- cron: "0 0 * * Wed"
+  displayName: Weekly Wednesday midnight run
   branches:
     include:
     - master
@@ -36,12 +36,15 @@ pool:
 variables:
 - group : Release Management Resources
 
-steps:
-- template: azure-pipelines-templates/build/step/gitversion.yml@das-platform-building-blocks
-- template: azure-pipelines-templates/build/step/dockerfile-build.yml@das-platform-building-blocks
-  parameters:
-    ContainerRegistryName: $(PublicAcrName)
-    ServiceConnection: SFA-DIG-Prod-ARM
-    ImageName: azure-pipelines-build-agent-ubuntu-20
-    WorkingDirectory: Linux/Build/Image
-    BranchToCreateLatestTag: master
+jobs:
+- job: ImageBuild
+  timeoutInMinutes: 120
+  steps:
+  - template: azure-pipelines-templates/build/step/gitversion.yml@das-platform-building-blocks
+  - template: azure-pipelines-templates/build/step/dockerfile-build.yml@das-platform-building-blocks
+    parameters:
+      ContainerRegistryName: $(PublicAcrName)
+      ServiceConnection: SFA-DIG-Prod-ARM
+      ImageName: azure-pipelines-build-agent-ubuntu-20
+      WorkingDirectory: Linux/Build/Image
+      BranchToCreateLatestTag: master

--- a/Windows/Build/Image/azure-pipelines.yml
+++ b/Windows/Build/Image/azure-pipelines.yml
@@ -26,7 +26,7 @@ resources:
     endpoint: SkillsFundingAgency
 
 schedules:
-- cron: "0 6 * * Wed"
+- cron: "0 3 * * Wed"
   displayName: Weekly Wednesday morning run
   branches:
     include:

--- a/Windows/Build/Image/azure-pipelines.yml
+++ b/Windows/Build/Image/azure-pipelines.yml
@@ -26,8 +26,8 @@ resources:
     endpoint: SkillsFundingAgency
 
 schedules:
-- cron: "0 6 * * Tue"
-  displayName: Weekly Tuesday morning build
+- cron: "0 6 * * Wed"
+  displayName: Weekly Wednesday morning run
   branches:
     include:
     - master
@@ -38,13 +38,16 @@ variables:
 - name: ContainerImageName
   value: azure-pipelines-build-agent-win
 
-steps:
-- template: azure-pipelines-templates/build/step/gitversion.yml@das-platform-building-blocks
-- template: azure-pipelines-templates/build/step/dockerfile-build.yml@das-platform-building-blocks
-  parameters:
-    ContainerRegistryName: $(PublicAcrName)
-    ServiceConnection: SFA-DIG-Prod-ARM
-    ImageName: $(ContainerImageName)
-    BranchToCreateLatestTag: master
-    Platform: windows
-    WorkingDirectory: Windows/Build/Image
+jobs:
+- job: ImageBuild
+  timeoutInMinutes: 120
+  steps:
+  - template: azure-pipelines-templates/build/step/gitversion.yml@das-platform-building-blocks
+  - template: azure-pipelines-templates/build/step/dockerfile-build.yml@das-platform-building-blocks
+    parameters:
+      ContainerRegistryName: $(PublicAcrName)
+      ServiceConnection: SFA-DIG-Prod-ARM
+      ImageName: $(ContainerImageName)
+      BranchToCreateLatestTag: master
+      Platform: windows
+      WorkingDirectory: Windows/Build/Image

--- a/Windows/Deploy/Image/azure-pipelines.yml
+++ b/Windows/Deploy/Image/azure-pipelines.yml
@@ -26,7 +26,7 @@ resources:
     endpoint: SkillsFundingAgency
 
 schedules:
-- cron: "0 6 * * Wed"
+- cron: "0 3 * * Wed"
   displayName: Weekly Wednesday morning run
   branches:
     include:

--- a/Windows/Deploy/Image/azure-pipelines.yml
+++ b/Windows/Deploy/Image/azure-pipelines.yml
@@ -26,8 +26,8 @@ resources:
     endpoint: SkillsFundingAgency
 
 schedules:
-- cron: "0 6 * * Tue"
-  displayName: Weekly Tuesday morning build
+- cron: "0 6 * * Wed"
+  displayName: Weekly Wednesday morning run
   branches:
     include:
     - master
@@ -37,14 +37,16 @@ variables:
 - group: Release Management Resources
 - name: ContainerImageName
   value: azure-pipelines-deploy-agent-win
-
-steps:
-- template: azure-pipelines-templates/build/step/gitversion.yml@das-platform-building-blocks
-- template: azure-pipelines-templates/build/step/dockerfile-build.yml@das-platform-building-blocks
-  parameters:
-    ContainerRegistryName: $(PublicAcrName)
-    ServiceConnection: SFA-DIG-Prod-ARM
-    ImageName: $(ContainerImageName)
-    BranchToCreateLatestTag: master
-    Platform: windows
-    WorkingDirectory: Windows/Deploy/Image
+jobs:
+- job: ImageBuild
+  timeoutInMinutes: 120
+  steps:
+  - template: azure-pipelines-templates/build/step/gitversion.yml@das-platform-building-blocks
+  - template: azure-pipelines-templates/build/step/dockerfile-build.yml@das-platform-building-blocks
+    parameters:
+      ContainerRegistryName: $(PublicAcrName)
+      ServiceConnection: SFA-DIG-Prod-ARM
+      ImageName: $(ContainerImageName)
+      BranchToCreateLatestTag: master
+      Platform: windows
+      WorkingDirectory: Windows/Deploy/Image


### PR DESCRIPTION
Scheduled runs for every Wednesday of the month. This is the to run after Patch Tuesday as it runs 5pm GMT.
Linux at midnight and windows at 6am

Added timeout of 120 minutes