### PR TITLE
Revert "Windows Deploy: Added choco install of pulumi"

### DIFF
--- a/Windows/Deploy/Image/Dockerfile
+++ b/Windows/Deploy/Image/Dockerfile
@@ -16,7 +16,6 @@ RUN choco install \
   git  \
   powershell-core \
   nodejs-lts \
-  pulumi \
   --confirm \
   --limit-output \
   --timeout 216000 \


### PR DESCRIPTION
Reverts SkillsFundingAgency/das-azure-pipelines-agents#110

pulumi Azure DevOps extension can be used instead of pulumi being pre-installed