### PR TITLE
Revert "Install Pulumi CLI on Linux Build (#125)"

### DIFF
--- a/Linux/Build/Image/Dockerfile
+++ b/Linux/Build/Image/Dockerfile
@@ -66,15 +66,6 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
 
-# Install Pulumi CLI
-RUN VERSION=$(curl --retry 3 --fail --silent -L "https://www.pulumi.com/latest-version") \
-  && mkdir -p $HOME/pulumi \
-  && curl https://get.pulumi.com/releases/sdk/pulumi-v${VERSION}-linux-x64.tar.gz -4 -o '/tmp/pulumicli.tar.gz' \
-  && tar -xvf /tmp/pulumicli.tar.gz -C $HOME/pulumi \
-  && mv $HOME/pulumi/pulumi $HOME/pulumi/bin \
-  && rm '/tmp/pulumicli.tar.gz'
-ENV PATH=$PATH:/root/pulumi/bin
-
 # Install MS SQL Server client tools (https://docs.microsoft.com/en-us/sql/linux/sql-server-linux-setup-tools?view=sql-server-2017)
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
   && curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list | tee /etc/apt/sources.list.d/msprod.list \


### PR DESCRIPTION
This reverts commit ace48c19f4191144b408602282084a312d918dfc.

When using the Pulumi Task it uses the azure-pipelines-tool-lib/tool findLocalTool function which only check the agents tool cache. It will not detect the pre-installed pulumi CLI.

https://github.com/pulumi/pulumi-az-pipelines-task/blob/master/buildAndReleaseTask/index.ts#L46