### PR TITLE
Remove task-cache mount configurations

### DIFF
--- a/Windows/Deploy/Deployment/manifest.yml
+++ b/Windows/Deploy/Deployment/manifest.yml
@@ -63,16 +63,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.name
-        volumeMounts:
-          - name: task-cache
-            mountPath: /azp/agent/_work/_tasks
       tolerations:
         - key: agent-os
           operator: Equal
           value: windows
           effect: NoSchedule
-      volumes:
-        - name: task-cache
-          hostPath:
-            path: /azp/agent/_work/_tasks
-            type: DirectoryOrCreate


### PR DESCRIPTION
### Context

Deployments keep erroring as the task-cache folder gets corrupted.

### Changes proposed in this pull request

Remove task-cache customisations as per: https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/windows-agent?view=azure-devops#agent-setup

### Testing

- [x] Deploy the change to the pre-prod AKS cluster
- [x] Change the agent of release to use the `DAS - Continuous Deployment Beta` agent pool
- [x] Confirmed there was no regression in the deployment succeeding

### Next steps

- [ ] Merge to master and ensure it reaches production