### PR TITLE
Update JDK to 17 for Linux and Windows images

### DIFF
--- a/Linux/Build/Deployment/azure-pipelines.yml
+++ b/Linux/Build/Deployment/azure-pipelines.yml
@@ -101,4 +101,3 @@ stages:
             VerifyDeployment: true
             Directory: $(System.DefaultWorkingDirectory)/Linux/Build/Deployment
             AzureServiceConnection: SFA-DIG-Prod-ARM
-

--- a/Linux/Build/Image/Dockerfile
+++ b/Linux/Build/Image/Dockerfile
@@ -62,9 +62,9 @@ RUN apt-get update \
 
 # Install Java OpenJDK
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends openjdk-11-jdk \
+  && apt-get install -y --no-install-recommends openjdk-17-jdk \
   && rm -rf /var/lib/apt/lists/*
-ENV JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
 
 # Install MS SQL Server client tools (https://docs.microsoft.com/en-us/sql/linux/sql-server-linux-setup-tools?view=sql-server-2017)
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \

--- a/Windows/Build/Image/Dockerfile
+++ b/Windows/Build/Image/Dockerfile
@@ -19,7 +19,14 @@ RUN choco install \
   git  \
   powershell-core \
   nodejs \
-  openjdk11 \
+  --confirm \
+  --limit-output \
+  --timeout 216000 \
+  && rmdir /S /Q C:\chococache
+
+RUN choco install \
+  openjdk \
+  --version=17.0.2 \
   --confirm \
   --limit-output \
   --timeout 216000 \


### PR DESCRIPTION
### Context

SonarCloud will stop working on JDK 11 so we need to update it to JDK 17

### Changes proposed in this pull request

Update JDK version from 11 to 17 for Linux and Windows build images

### Testing

- [x] Created a new container image using the image build pipeline in ADO
- [x] Updated the deploy pipeline to manually fix the ImageTag variable in `Linux/Build/Deployment/azure-pipelines.yml` to that created from the image build pipeline
- [x] Tested SonarCloud against the new JDK image by updating the aaa-hub-api project to use the Beta integration agents. [Result](https://github.com/SkillsFundingAgency/das-aan-hub-api/pull/149/checks?check_run_id=18304143750) shows no warning about the JDK version.

### Next steps

- [ ] Merge the change to master and ensure the image is deployed to the non-Beta agents