### PR TITLE
DASD-14528 - Infrastructure - Enable .NET 10 within DevOps build agents

### DIFF
--- a/Linux/Build/Image/Dockerfile
+++ b/Linux/Build/Image/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 # To make it easier for build and release pipelines to run apt-get,
 # configure apt to not require confirmation (assume the -y argument by default)
@@ -19,9 +19,8 @@ RUN apt-get update \
   iproute2 \
   iputils-ping \
   libcurl4 \
-  libicu66 \
+  libicu70 \
   libunwind8 \
-  libssl1.0 \
   locales \
   openssh-client \
   netcat \
@@ -68,7 +67,7 @@ ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
 
 # Install MS SQL Server client tools (https://docs.microsoft.com/en-us/sql/linux/sql-server-linux-setup-tools?view=sql-server-2017)
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
-  && curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list | tee /etc/apt/sources.list.d/msprod.list \
+  && curl https://packages.microsoft.com/config/ubuntu/22.04/prod.list | tee /etc/apt/sources.list.d/msprod.list \
   && apt-get update \
   && apt-get install -y --no-install-recommends \
   mssql-tools \
@@ -78,25 +77,27 @@ RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
   || echo -n
 ENV PATH=$PATH:/opt/mssql-tools/bin
 
-# Install .NET Core SDK and initialize package cache
-RUN curl https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb > packages-microsoft-prod.deb \
-  && dpkg -i packages-microsoft-prod.deb \
-  && rm packages-microsoft-prod.deb \
+# Install .NET SDKs from Ubuntu .NET Backports PPA
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends software-properties-common \
+  && add-apt-repository -y ppa:dotnet/backports \
   && apt-get update \
   && apt-get install -y --no-install-recommends \
-  dotnet-sdk-3.1 \
   dotnet-sdk-6.0 \
   dotnet-sdk-8.0 \
-  && rm -rf /var/lib/apt/lists/* \
-  && rm -rf /etc/apt/sources.list.d/*
+  dotnet-sdk-10.0 \
+  && rm -rf /var/lib/apt/lists/*
 RUN dotnet help
 ENV dotnet=/usr/bin/dotnet
 
 # TODO: Delete this when no longer referenced by pipelines
 ENV LATEST_DOTNET_VERSION=3.1
 
-#Manually install .NET Core 2.2 SDK
+# Manually install .NET Core 2.2 SDK
 RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 2.2 --install-dir /usr/share/dotnet
+
+# Manually install .NET Core 3.1 SDK
+RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 3.1 --install-dir /usr/share/dotnet
 
 # Install LTS Node.js and related tools
 RUN curl -sL https://git.io/n-install | bash -s -- -ny - \
@@ -111,7 +112,7 @@ ENV grunt=/usr/local/bin/grunt
 
 # Install Powershell Core
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
-  && curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list | tee /etc/apt/sources.list.d/microsoft.list \
+  && curl https://packages.microsoft.com/config/ubuntu/22.04/prod.list | tee /etc/apt/sources.list.d/microsoft.list \
   && apt-get update \
   && apt-get install -y --no-install-recommends \
   powershell \
@@ -127,6 +128,7 @@ RUN apt-get update \
   && apt-get install -y lsb-release \
   && AZ_REPO=$(lsb_release -cs) \
   && echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" | tee /etc/apt/sources.list.d/azure-cli.list \
+  && apt-get update \
   && apt-get install -y azure-cli
 
 # Clean system


### PR DESCRIPTION
### What changed
- Removed the Microsoft packages-microsoft-prod feed for SDK installs
- Added the ppa:dotnet/backports PPA as the source for .NET SDKs 6.0, 8.0, and 10.0
- .NET 3.1 and 2.2 remain installed via dotnet-install.sh (unchanged)

### Key findings
- dotnet-sdk-10.0 is NOT in the Microsoft feed — the packages-microsoft-prod repo for Ubuntu 22.04 only goes up to SDK 9.0
- The Ubuntu .NET Backports PPA (ppa:dotnet/backports) has it — this is maintained by Canonical and provides .NET 10 for 22.04+
- Ubuntu 22.04 is the minimum for backports — the PPA does not support 20.04 or older, so the base image must stay ubuntu:22.04 (or newer)
- Consolidating to one feed avoids conflicts — mixing the Microsoft feed with the Ubuntu PPA can cause package conflicts, so we moved all three SDKs (6.0, 8.0, 10.0) to the PPA
- libssl1.0 is not on 22.04 — Ubuntu 22.04 ships OpenSSL 3.0 (libssl3). Older .NET SDKs (2.2, 3.1) work via dotnet-install.sh which handles its own dependencies