### PR TITLE
New pipeline to clear disk storage of windows deploy agents

### DIFF
--- a/Windows/azure-pipelines.yml
+++ b/Windows/azure-pipelines.yml
@@ -12,11 +12,11 @@ stages:
 - stage: clear_wndpy
   displayName: Clear PVCs in Windows Deploy Node Pool 
   jobs:
-  - job: clear_pods
+  - job: clear_pod
     strategy:
       matrix:
-        # pod00:
-        #   agentName: azure-pipelines-deploy-agent-win-0-0
+        pod00:
+          agentName: azure-pipelines-deploy-agent-win-0-0
         # pod01:
         #   agentName: azure-pipelines-deploy-agent-win-0-1
         # pod02:
@@ -53,11 +53,68 @@ stages:
         #   agentName: azure-pipelines-deploy-agent-win-4-1
         # pod42:
         #   agentName: azure-pipelines-deploy-agent-win-4-2
-        pod43:
-          agentName: azure-pipelines-deploy-agent-win-4-3
+        # pod43:
+        #   agentName: azure-pipelines-deploy-agent-win-4-3
       maxParallel: 4
     pool:
       name: DAS - Continuous Deployment Agents
+      demands: Agent.Name -equals $(agentName)
+    steps:
+      - pwsh: |
+          Set-Location ../..
+          Get-ChildItem .\_tasks |
+            Where-Object { $_.Name -notlike 'Powershell*' } |
+            Remove-Item -Recurse -Force
+
+- stage: clear_apmdp
+  displayName: Clear PVCs in APIM Deploy Node Pool 
+  jobs:
+  - job: clear_pod
+    strategy:
+      matrix:
+        pod00:
+          agentName: azure-pipelines-apim-deploy-agent-win-0-0
+        # pod01:
+        #   agentName: azure-pipelines-apim-deploy-agent-win-0-1
+        # pod02:
+        #   agentName: azure-pipelines-apim-deploy-agent-win-0-2
+        # pod03:
+        #   agentName: azure-pipelines-apim-deploy-agent-win-0-3
+        # pod10:
+        #   agentName: azure-pipelines-apim-deploy-agent-win-1-0
+        # pod11:
+        #   agentName: azure-pipelines-apim-deploy-agent-win-1-1
+        # pod12:
+        #   agentName: azure-pipelines-apim-deploy-agent-win-1-2
+        # pod13:
+        #   agentName: azure-pipelines-apim-deploy-agent-win-1-3
+        # pod20:
+        #   agentName: azure-pipelines-apim-deploy-agent-win-2-0
+        # pod21:
+        #   agentName: azure-pipelines-apim-deploy-agent-win-2-1
+        # pod22:
+        #   agentName: azure-pipelines-apim-deploy-agent-win-2-2
+        # pod23:
+        #   agentName: azure-pipelines-apim-deploy-agent-win-2-3
+        # pod30:
+        #   agentName: azure-pipelines-apim-deploy-agent-win-3-0
+        # pod31:
+        #   agentName: azure-pipelines-apim-deploy-agent-win-3-1
+        # pod32:
+        #   agentName: azure-pipelines-apim-deploy-agent-win-3-2
+        # pod33:
+        #   agentName: azure-pipelines-apim-deploy-agent-win-3-3
+        # pod40:
+        #   agentName: azure-pipelines-apim-deploy-agent-win-4-0
+        # pod41:
+        #   agentName: azure-pipelines-apim-deploy-agent-win-4-1
+        # pod42:
+        #   agentName: azure-pipelines-apim-deploy-agent-win-4-2
+        # pod43:
+        #   agentName: azure-pipelines-apim-deploy-agent-win-4-3
+      maxParallel: 4
+    pool:
+      name: DAS - APIM Continuous Deployment Agents
       demands: Agent.Name -equals $(agentName)
     steps:
       - pwsh: |

--- a/Windows/azure-pipelines.yml
+++ b/Windows/azure-pipelines.yml
@@ -9,24 +9,57 @@ trigger:
 #     - main
 
 stages:
-- stage: clear_node0
-  displayName: Clear PVCs in Node 0
+- stage: clear_wndpy
+  displayName: Clear PVCs in Windows Deploy Node Pool 
   jobs:
   - job: clear_pods
     strategy:
       matrix:
-        pod0:
+        pod00:
           agentName: azure-pipelines-deploy-agent-win-0-0
-        pod1:
-          agentName: azure-pipelines-deploy-agent-win-0-1
-        pod2:
-          agentName: azure-pipelines-deploy-agent-win-0-2
-        pod3:
-          agentName: azure-pipelines-deploy-agent-win-0-3
+        # pod01:
+        #   agentName: azure-pipelines-deploy-agent-win-0-1
+        # pod02:
+        #   agentName: azure-pipelines-deploy-agent-win-0-2
+        # pod03:
+        #   agentName: azure-pipelines-deploy-agent-win-0-3
+        # pod10:
+        #   agentName: azure-pipelines-deploy-agent-win-1-0
+        # pod11:
+        #   agentName: azure-pipelines-deploy-agent-win-1-1
+        # pod12:
+        #   agentName: azure-pipelines-deploy-agent-win-1-2
+        # pod13:
+        #   agentName: azure-pipelines-deploy-agent-win-1-3
+        # pod20:
+        #   agentName: azure-pipelines-deploy-agent-win-2-0
+        # pod21:
+        #   agentName: azure-pipelines-deploy-agent-win-2-1
+        # pod22:
+        #   agentName: azure-pipelines-deploy-agent-win-2-2
+        # pod23:
+        #   agentName: azure-pipelines-deploy-agent-win-2-3
+        # pod30:
+        #   agentName: azure-pipelines-deploy-agent-win-3-0
+        # pod31:
+        #   agentName: azure-pipelines-deploy-agent-win-3-1
+        # pod32:
+        #   agentName: azure-pipelines-deploy-agent-win-3-2
+        # pod33:
+        #   agentName: azure-pipelines-deploy-agent-win-3-3
+        # pod40:
+        #   agentName: azure-pipelines-deploy-agent-win-4-0
+        # pod41:
+        #   agentName: azure-pipelines-deploy-agent-win-4-1
+        # pod42:
+        #   agentName: azure-pipelines-deploy-agent-win-4-2
+        # pod43:
+        #   agentName: azure-pipelines-deploy-agent-win-4-3
       maxParallel: 4
     pool:
       name: DAS - Continuous Deployment Agents
       demands: Agent.Name -equals $(agentName)
     steps:
       - pwsh: |
-          ls
+          Set-Location ../../..
+          Remove-Item -Recurse .\_tasks\

--- a/Windows/azure-pipelines.yml
+++ b/Windows/azure-pipelines.yml
@@ -15,8 +15,8 @@ stages:
   - job: clear_pods
     strategy:
       matrix:
-        pod00:
-          agentName: azure-pipelines-deploy-agent-win-0-0
+        # pod00:
+        #   agentName: azure-pipelines-deploy-agent-win-0-0
         # pod01:
         #   agentName: azure-pipelines-deploy-agent-win-0-1
         # pod02:
@@ -53,8 +53,8 @@ stages:
         #   agentName: azure-pipelines-deploy-agent-win-4-1
         # pod42:
         #   agentName: azure-pipelines-deploy-agent-win-4-2
-        # pod43:
-        #   agentName: azure-pipelines-deploy-agent-win-4-3
+        pod43:
+          agentName: azure-pipelines-deploy-agent-win-4-3
       maxParallel: 4
     pool:
       name: DAS - Continuous Deployment Agents

--- a/Windows/azure-pipelines.yml
+++ b/Windows/azure-pipelines.yml
@@ -62,5 +62,4 @@ stages:
     steps:
       - pwsh: |
           Set-Location ../..
-          whoami
-          # Remove-Item -Recurse .\_tasks\*
+          Remove-Item -Recurse .\_tasks\*

--- a/Windows/azure-pipelines.yml
+++ b/Windows/azure-pipelines.yml
@@ -2,13 +2,11 @@ trigger:
 - none
 
 schedules:
-- cron: '0 2 1-7 * */2'
-# - cron: '0 2 1-7 * */7' # change to 0 2 1 * * if it doesn't work
+- cron: '0 2 1-7 * 6'
   displayName: Monthly storage disc clean
   branches:
     include:
-    # - main
-    - dasd-15471
+    - main
   always: true
 
 stages:
@@ -20,44 +18,44 @@ stages:
       matrix:
         pod00:
           agentName: azure-pipelines-deploy-agent-win-0-0
-        # pod01:
-        #   agentName: azure-pipelines-deploy-agent-win-0-1
-        # pod02:
-        #   agentName: azure-pipelines-deploy-agent-win-0-2
-        # pod03:
-        #   agentName: azure-pipelines-deploy-agent-win-0-3
-        # pod10:
-        #   agentName: azure-pipelines-deploy-agent-win-1-0
-        # pod11:
-        #   agentName: azure-pipelines-deploy-agent-win-1-1
-        # pod12:
-        #   agentName: azure-pipelines-deploy-agent-win-1-2
-        # pod13:
-        #   agentName: azure-pipelines-deploy-agent-win-1-3
-        # pod20:
-        #   agentName: azure-pipelines-deploy-agent-win-2-0
-        # pod21:
-        #   agentName: azure-pipelines-deploy-agent-win-2-1
-        # pod22:
-        #   agentName: azure-pipelines-deploy-agent-win-2-2
-        # pod23:
-        #   agentName: azure-pipelines-deploy-agent-win-2-3
-        # pod30:
-        #   agentName: azure-pipelines-deploy-agent-win-3-0
-        # pod31:
-        #   agentName: azure-pipelines-deploy-agent-win-3-1
-        # pod32:
-        #   agentName: azure-pipelines-deploy-agent-win-3-2
-        # pod33:
-        #   agentName: azure-pipelines-deploy-agent-win-3-3
-        # pod40:
-        #   agentName: azure-pipelines-deploy-agent-win-4-0
-        # pod41:
-        #   agentName: azure-pipelines-deploy-agent-win-4-1
-        # pod42:
-        #   agentName: azure-pipelines-deploy-agent-win-4-2
-        # pod43:
-        #   agentName: azure-pipelines-deploy-agent-win-4-3
+        pod01:
+          agentName: azure-pipelines-deploy-agent-win-0-1
+        pod02:
+          agentName: azure-pipelines-deploy-agent-win-0-2
+        pod03:
+          agentName: azure-pipelines-deploy-agent-win-0-3
+        pod10:
+          agentName: azure-pipelines-deploy-agent-win-1-0
+        pod11:
+          agentName: azure-pipelines-deploy-agent-win-1-1
+        pod12:
+          agentName: azure-pipelines-deploy-agent-win-1-2
+        pod13:
+          agentName: azure-pipelines-deploy-agent-win-1-3
+        pod20:
+          agentName: azure-pipelines-deploy-agent-win-2-0
+        pod21:
+          agentName: azure-pipelines-deploy-agent-win-2-1
+        pod22:
+          agentName: azure-pipelines-deploy-agent-win-2-2
+        pod23:
+          agentName: azure-pipelines-deploy-agent-win-2-3
+        pod30:
+          agentName: azure-pipelines-deploy-agent-win-3-0
+        pod31:
+          agentName: azure-pipelines-deploy-agent-win-3-1
+        pod32:
+          agentName: azure-pipelines-deploy-agent-win-3-2
+        pod33:
+          agentName: azure-pipelines-deploy-agent-win-3-3
+        pod40:
+          agentName: azure-pipelines-deploy-agent-win-4-0
+        pod41:
+          agentName: azure-pipelines-deploy-agent-win-4-1
+        pod42:
+          agentName: azure-pipelines-deploy-agent-win-4-2
+        pod43:
+          agentName: azure-pipelines-deploy-agent-win-4-3
       maxParallel: 4
     pool:
       name: DAS - Continuous Deployment Agents
@@ -77,44 +75,44 @@ stages:
       matrix:
         pod00:
           agentName: azure-pipelines-apim-deploy-agent-win-0-0
-        # pod01:
-        #   agentName: azure-pipelines-apim-deploy-agent-win-0-1
-        # pod02:
-        #   agentName: azure-pipelines-apim-deploy-agent-win-0-2
-        # pod03:
-        #   agentName: azure-pipelines-apim-deploy-agent-win-0-3
-        # pod10:
-        #   agentName: azure-pipelines-apim-deploy-agent-win-1-0
-        # pod11:
-        #   agentName: azure-pipelines-apim-deploy-agent-win-1-1
-        # pod12:
-        #   agentName: azure-pipelines-apim-deploy-agent-win-1-2
-        # pod13:
-        #   agentName: azure-pipelines-apim-deploy-agent-win-1-3
-        # pod20:
-        #   agentName: azure-pipelines-apim-deploy-agent-win-2-0
-        # pod21:
-        #   agentName: azure-pipelines-apim-deploy-agent-win-2-1
-        # pod22:
-        #   agentName: azure-pipelines-apim-deploy-agent-win-2-2
-        # pod23:
-        #   agentName: azure-pipelines-apim-deploy-agent-win-2-3
-        # pod30:
-        #   agentName: azure-pipelines-apim-deploy-agent-win-3-0
-        # pod31:
-        #   agentName: azure-pipelines-apim-deploy-agent-win-3-1
-        # pod32:
-        #   agentName: azure-pipelines-apim-deploy-agent-win-3-2
-        # pod33:
-        #   agentName: azure-pipelines-apim-deploy-agent-win-3-3
-        # pod40:
-        #   agentName: azure-pipelines-apim-deploy-agent-win-4-0
-        # pod41:
-        #   agentName: azure-pipelines-apim-deploy-agent-win-4-1
-        # pod42:
-        #   agentName: azure-pipelines-apim-deploy-agent-win-4-2
-        # pod43:
-        #   agentName: azure-pipelines-apim-deploy-agent-win-4-3
+        pod01:
+          agentName: azure-pipelines-apim-deploy-agent-win-0-1
+        pod02:
+          agentName: azure-pipelines-apim-deploy-agent-win-0-2
+        pod03:
+          agentName: azure-pipelines-apim-deploy-agent-win-0-3
+        pod10:
+          agentName: azure-pipelines-apim-deploy-agent-win-1-0
+        pod11:
+          agentName: azure-pipelines-apim-deploy-agent-win-1-1
+        pod12:
+          agentName: azure-pipelines-apim-deploy-agent-win-1-2
+        pod13:
+          agentName: azure-pipelines-apim-deploy-agent-win-1-3
+        pod20:
+          agentName: azure-pipelines-apim-deploy-agent-win-2-0
+        pod21:
+          agentName: azure-pipelines-apim-deploy-agent-win-2-1
+        pod22:
+          agentName: azure-pipelines-apim-deploy-agent-win-2-2
+        pod23:
+          agentName: azure-pipelines-apim-deploy-agent-win-2-3
+        pod30:
+          agentName: azure-pipelines-apim-deploy-agent-win-3-0
+        pod31:
+          agentName: azure-pipelines-apim-deploy-agent-win-3-1
+        pod32:
+          agentName: azure-pipelines-apim-deploy-agent-win-3-2
+        pod33:
+          agentName: azure-pipelines-apim-deploy-agent-win-3-3
+        pod40:
+          agentName: azure-pipelines-apim-deploy-agent-win-4-0
+        pod41:
+          agentName: azure-pipelines-apim-deploy-agent-win-4-1
+        pod42:
+          agentName: azure-pipelines-apim-deploy-agent-win-4-2
+        pod43:
+          agentName: azure-pipelines-apim-deploy-agent-win-4-3
       maxParallel: 4
     pool:
       name: DAS - APIM Continuous Deployment Agents

--- a/Windows/azure-pipelines.yml
+++ b/Windows/azure-pipelines.yml
@@ -1,0 +1,32 @@
+trigger:
+- none
+
+# schedules:
+# - cron: '0 2 1 * *'
+#   displayName: Monthly storage disc clean
+#   branches:
+#     include:
+#     - main
+
+stages:
+- stage: clear_node0
+  displayName: Clear PVCs in Node 0
+  jobs:
+  - job: clear_pods
+    strategy:
+      matrix:
+        pod0:
+          agentName: azure-pipelines-deploy-agent-win-0-0
+        pod1:
+          agentName: azure-pipelines-deploy-agent-win-0-1
+        pod2:
+          agentName: azure-pipelines-deploy-agent-win-0-2
+        pod3:
+          agentName: azure-pipelines-deploy-agent-win-0-3
+      maxParallel: 4
+    pool:
+      name: DAS - Continuous Deployment Agents
+      demands: Agent.Name -equals $(agentName)
+    steps:
+      - pwsh: |
+          ls

--- a/Windows/azure-pipelines.yml
+++ b/Windows/azure-pipelines.yml
@@ -1,12 +1,13 @@
 trigger:
 - none
 
-# schedules:
-# - cron: '0 2 1 * *'
-#   displayName: Monthly storage disc clean
-#   branches:
-#     include:
-#     - main
+schedules:
+- cron: '0 2 1-7 * */2' # change /2 to /7 if it works, else 0 2 1 * *
+  displayName: Monthly storage disc clean
+  branches:
+    include:
+    - main
+  always: true
 
 stages:
 - stage: clear_wndpy

--- a/Windows/azure-pipelines.yml
+++ b/Windows/azure-pipelines.yml
@@ -62,4 +62,6 @@ stages:
     steps:
       - pwsh: |
           Set-Location ../..
-          Remove-Item -Recurse .\_tasks\*
+          Get-ChildItem .\_tasks |
+            Where-Object { $_.Name -notlike 'Powershell*' } |
+            Remove-Item -Recurse -Force

--- a/Windows/azure-pipelines.yml
+++ b/Windows/azure-pipelines.yml
@@ -62,4 +62,5 @@ stages:
     steps:
       - pwsh: |
           Set-Location ../../..
-          Remove-Item -Recurse .\_tasks\
+          Get-Location
+          # Remove-Item -Recurse .\_tasks\

--- a/Windows/azure-pipelines.yml
+++ b/Windows/azure-pipelines.yml
@@ -61,6 +61,6 @@ stages:
       demands: Agent.Name -equals $(agentName)
     steps:
       - pwsh: |
-          Set-Location ../../..
+          Set-Location ../..
           Get-Location
           # Remove-Item -Recurse .\_tasks\

--- a/Windows/azure-pipelines.yml
+++ b/Windows/azure-pipelines.yml
@@ -62,5 +62,5 @@ stages:
     steps:
       - pwsh: |
           Set-Location ../..
-          Get-Location
-          # Remove-Item -Recurse .\_tasks\
+          Remove-Item -Recurse .\_tasks\
+          # Get-Location

--- a/Windows/azure-pipelines.yml
+++ b/Windows/azure-pipelines.yml
@@ -2,11 +2,13 @@ trigger:
 - none
 
 schedules:
-- cron: '0 2 1-7 * */2' # change /2 to /7 if it works, else 0 2 1 * *
+- cron: '0 2 1-7 * */2'
+# - cron: '0 2 1-7 * */7' # change to 0 2 1 * * if it doesn't work
   displayName: Monthly storage disc clean
   branches:
     include:
-    - main
+    # - main
+    - dasd-15471
   always: true
 
 stages:

--- a/Windows/azure-pipelines.yml
+++ b/Windows/azure-pipelines.yml
@@ -1,5 +1,6 @@
-trigger:
-- none
+trigger: none
+
+pr: none
 
 schedules:
 - cron: '0 2 1-7 * 6'

--- a/Windows/azure-pipelines.yml
+++ b/Windows/azure-pipelines.yml
@@ -62,5 +62,5 @@ stages:
     steps:
       - pwsh: |
           Set-Location ../..
-          Remove-Item -Recurse .\_tasks\
+          Remove-Item -Recurse .\_tasks\*
           # Get-Location

--- a/Windows/azure-pipelines.yml
+++ b/Windows/azure-pipelines.yml
@@ -62,5 +62,5 @@ stages:
     steps:
       - pwsh: |
           Set-Location ../..
-          Remove-Item -Recurse .\_tasks\*
-          # Get-Location
+          whoami
+          # Remove-Item -Recurse .\_tasks\*


### PR DESCRIPTION
Pipeline is scheduled to run on the first Saturday of the month at 2:00 am. It will clear the azp/agent/_work/_tasks directory which is there all the tasks downloaded in the initialise job step are saved. The powershell task is not removed as the pipeline will be using the powershell task to remove the other files

[pipeline run](https://dev.azure.com/sfa-gov-uk/Apprenticeships%20Service%20Cloud%20Platform/_build/results?buildId=1118782&view=results)